### PR TITLE
Initial cut of an Ansible role to register a Wireguard public key with AWS SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+Ansible Role: wireguard-ssm
+=========
+
+Provide glue for reading and writing Wireguard configuration in AWS Systems Manager Parameter Store.
+
+The idea behind this role is to have an off-host location to store a sinle Wireguard EC2 instance's public key. The requirements were:
+* Replace OpenVPN
+* Single Wireguard VPN endpoint per AWS region
+* Make the endpoint instances ephemeral, store useful information off-host
+
+There are intentions to extend this role to apply wireguard peer configuration which will be populated directly into Parameter Store.
+
+Thanks to [githubixx](https://github.com/githubixx) and contributors for [ansible-role-wireguard](https://github.com/githubixx/ansible-role-wireguard).
+
+Requirements
+------------
+
+A running EC2 instance with an IAM policy assigned which will allow read/write access to AWS SSM Parameter Store.
+
+This module requires the following:
+
+    collections:
+      - name: amazon.aws
+        version: 1.4.0
+      - name: community.aws
+        version: 1.3.0
+
+
+
+
+Role Variables
+--------------
+
+Customisable variables have been declared in `defaults/main.yml`.
+
+The base directory for Parameter Store:
+
+      wireguard_ssm_base_path: "/wireguard"
+
+Deploying this on an `us-east-1` instance, will create the following parameter path:
+
+      /wireguard/us-east-1/public_key
+
+Dependencies
+------------
+
+You will need a running instance of Wireguard on the EC2 instance and a policy assigned to the EC2 instance's role which will permit read/write access to SSM Parameter Store, ideally you have limited it to the value of `wireguard_ssm_base_path`.
+
+Although this role does not explcitly depend on [githubixx.ansible-role-wireguard](https://github.com/githubixx/ansible-role-wireguard), it was used in the testing.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    hosts:
+      localhost:
+      roles:
+        - role: gavmain.wireguard-ssm
+          vars:
+            wireguard_ssm_base_path: /wireguard
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+This role was created in 2021 by [Gav Main](https://github.com/gavmain).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# defaults file for wireguard-ssm
+wireguard_ssm_rpms:
+- python-pip
+
+wireguard_ssm_py_pkgs:
+  - boto3
+  - botocore
+
+wireguard_ssm_base_path: "/wireguard"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for wireguard-ssm

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  role_name: wireguard-ssm
+  author: gavmain
+  description: Registers the public key of a Wireguard EC2 instance to AWS SSM Parameter Store
+  license: MIT
+  min_ansible_version: 2.9
+  platforms:
+    - name: EL
+      versions:
+      - 7
+  galaxy_tags:
+    - wireguard
+    - aws
+    - ssm
+    - ec2
+    - amazon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# tasks file for wireguard-ssm
+- name: Install AWS SSM RPM dependencies
+  yum:
+    name: "{{ wireguard_ssm_rpms }}"
+
+- name: Install AWS SSM Python dependencies
+  pip:
+    name: "{{ wireguard_ssm_py_pkgs }}"
+
+- name: Gather EC2 facts
+  amazon.aws.ec2_metadata_facts:
+
+- name: Register 'wg showconf wg0'
+  command: "wg showconf wg0"
+  register: __wg_showconf
+  changed_when: false
+
+- name: private_key fact
+  set_fact:
+    __pri_key: "{{ __wg_showconf.stdout | regex_findall('PrivateKey = (.*)') | first }}"
+
+- name: generate public_key
+  command: "wg pubkey"
+  args:
+    stdin: "{{ __pri_key }}"
+  register: __pub_key
+  changed_when: false
+  check_mode: no
+
+- name: Store regional WireGuard public key
+  community.aws.aws_ssm_parameter_store:
+    name: "{{ wireguard_ssm_base_path }}/{{ ansible_ec2_placement_availability_zone }}/public_key"
+    description: "Public key for the {{ ansible_ec2_placement_availability_zone }} region"
+    region: "{{ ansible_ec2_placement_region }}"
+    value: "{{ __pub_key.stdout }}"
+    string_type: "String"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - wireguard-ssm

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for wireguard-ssm


### PR DESCRIPTION
Ready for the first release. This is a functioning role to register the public key of the new Wireguard endpoint with AWS SSM Parameter Store, which can be accessible at a later point.